### PR TITLE
Refactor request handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { serveStatic } from 'hono/cloudflare-workers';
 import { workerIoE } from './io';
 import { ScannerFactory } from './scanner/factory';
 import { Document, DocumentType } from './ocr/types';
+import { handleDocumentRequest } from './request-handlers';
 // Import Swagger UI middleware
 import { createSwaggerUI, getOpenAPISpecWithCurrentVersion } from './swagger';
 // Get package version (used in health check)
@@ -136,126 +137,10 @@ app.post('/process', async (c) => {
 });
 
 // Dedicated endpoint for check processing
-app.post('/check', async (c) => {
-  try {
-    // Check content type
-    const contentType = c.req.header('Content-Type');
-    if (!contentType?.startsWith('image/')) {
-      return new Response(JSON.stringify({ error: 'Invalid content type. Expected image/*' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
-    // Get document format (image/pdf) from query
-    const documentFormat = c.req.query('format') || 'image';
-    const documentType = documentFormat === 'pdf' ? DocumentType.PDF : DocumentType.Image;
-    
-    // Get image data
-    const imageBuffer = await c.req.arrayBuffer();
-
-    // Create check scanner
-    const scanner = ScannerFactory.createMistralCheckScanner(workerIoE, c.env.MISTRAL_API_KEY);
-
-    // Create document
-    const document: Document = {
-      content: imageBuffer,
-      type: documentType,
-      name: c.req.query('filename') || 'check-document'
-    };
-
-    // Process document
-    const result = await scanner.processDocument(document);
-
-    // Handle result
-    if (result[0] === 'error') {
-      return new Response(JSON.stringify({ error: result[1] }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
-    // Return processing result
-    return new Response(JSON.stringify({
-      data: result[1].json,
-      confidence: {
-        ocr: result[1].ocrConfidence,
-        extraction: result[1].extractionConfidence,
-        overall: result[1].overallConfidence
-      }
-    }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' }
-    });
-  } catch (error) {
-    console.error('Error processing check:', error);
-    return new Response(JSON.stringify({ message: 'Internal server error', error }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' }
-    });
-  }
-});
+app.post('/check', (c) => handleDocumentRequest(c, 'check'));
 
 // Dedicated endpoint for receipt processing
-app.post('/receipt', async (c) => {
-  try {
-    // Check content type
-    const contentType = c.req.header('Content-Type');
-    if (!contentType?.startsWith('image/')) {
-      return new Response(JSON.stringify({ error: 'Invalid content type. Expected image/*' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
-    // Get document format (image/pdf) from query
-    const documentFormat = c.req.query('format') || 'image';
-    const documentType = documentFormat === 'pdf' ? DocumentType.PDF : DocumentType.Image;
-    
-    // Get image data
-    const imageBuffer = await c.req.arrayBuffer();
-
-    // Create receipt scanner
-    const scanner = ScannerFactory.createMistralReceiptScanner(workerIoE, c.env.MISTRAL_API_KEY);
-
-    // Create document
-    const document: Document = {
-      content: imageBuffer,
-      type: documentType,
-      name: c.req.query('filename') || 'receipt-document'
-    };
-
-    // Process document
-    const result = await scanner.processDocument(document);
-
-    // Handle result
-    if (result[0] === 'error') {
-      return new Response(JSON.stringify({ error: result[1] }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
-    // Return processing result
-    return new Response(JSON.stringify({
-      data: result[1].json,
-      confidence: {
-        ocr: result[1].ocrConfidence,
-        extraction: result[1].extractionConfidence,
-        overall: result[1].overallConfidence
-      }
-    }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' }
-    });
-  } catch (error) {
-    console.error('Error processing receipt:', error);
-    return new Response(JSON.stringify({ message: 'Internal server error', error }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' }
-    });
-  }
-});
+app.post('/receipt', (c) => handleDocumentRequest(c, 'receipt'));
 
 // Health check endpoint for testing server availability and API key configuration
 app.get('/health', (c) => {

--- a/src/request-handlers.ts
+++ b/src/request-handlers.ts
@@ -1,0 +1,70 @@
+import type { Context } from 'hono';
+import { workerIoE } from './io';
+import { ScannerFactory } from './scanner/factory';
+import { Document, DocumentType } from './ocr/types';
+import type { Env } from './types';
+
+/**
+ * Handle OCR requests for specific document types.
+ * Shared by the /check and /receipt endpoints.
+ */
+export async function handleDocumentRequest(
+  c: Context<{ Bindings: Env }>,
+  type: 'check' | 'receipt'
+): Promise<Response> {
+  try {
+    const contentType = c.req.header('Content-Type');
+    if (!contentType?.startsWith('image/')) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid content type. Expected image/*' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const documentFormat = c.req.query('format') || 'image';
+    const documentType =
+      documentFormat === 'pdf' ? DocumentType.PDF : DocumentType.Image;
+
+    const imageBuffer = await c.req.arrayBuffer();
+
+    const scanner = ScannerFactory.createScannerByType(
+      workerIoE,
+      c.env.MISTRAL_API_KEY,
+      type
+    );
+
+    const document: Document = {
+      content: imageBuffer,
+      type: documentType,
+      name: c.req.query('filename') || `${type}-document`
+    };
+
+    const result = await scanner.processDocument(document);
+
+    if (result[0] === 'error') {
+      return new Response(JSON.stringify({ error: result[1] }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        data: result[1].json,
+        confidence: {
+          ocr: result[1].ocrConfidence,
+          extraction: result[1].extractionConfidence,
+          overall: result[1].overallConfidence
+        }
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error(`Error processing ${type}:`, error);
+    return new Response(
+      JSON.stringify({ message: 'Internal server error', error }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- create `handleDocumentRequest` helper to share validation/processing logic
- use the helper in `/check` and `/receipt` routes

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*
- `npm test` *(fails: Cannot find module 'ts-node/esm')*