### PR TITLE
Use shared Env type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,7 @@ import { Document, DocumentType } from './ocr/types';
 import { createSwaggerUI, getOpenAPISpecWithCurrentVersion } from './swagger';
 // Get package version (used in health check)
 import pkg from '../package.json';
-
-interface Env {
-  MISTRAL_API_KEY: string;
-}
+import type { Env } from './types';
 
 const app = new Hono<{ Bindings: Env }>();
 // Apply CORS middleware to all routes


### PR DESCRIPTION
## Summary
- remove duplicated `Env` interface from `src/index.ts`
- import `Env` from shared types and apply to the Hono app

## Testing
- `npm test` *(fails: OCR processing failed)*